### PR TITLE
Modules reafactor zfs / impermanence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All datasets that say "no mount" may not be mounted and instead are policy conta
 
 This idea is mostly taken from Graham Christensen's blog post "Erase your darlings".
 
-NixOS boots as long as it has access to `/boot` and `/nix`. If `hyperparabolic.base.zfs.rollbackSnapshot` is specified, `zfs rollback -r %snapshot%` is executed immediately after filesystems are mounted in initrd, in this case rolling back to a blank filesystem snapshot of `/rpool/crypt/local/root`.  By default there is zero config drift, and the system always boots with "new system smell."
+NixOS boots as long as it has access to `/boot` and `/nix`. If `hyperparabolic.zfs.rollbackSnapshot` is specified, `zfs rollback -r %snapshot%` is executed immediately after filesystems are mounted in initrd, in this case rolling back to a blank filesystem snapshot of `/rpool/crypt/local/root`.  By default there is zero config drift, and the system always boots with "new system smell."
 
 [Impermanence](https://nixos.wiki/wiki/Impermanence) allows opt-in persistence of specific files and directories between boots. `/persist` is a mirror of the root filesystem only containing directories and files to persist between boots, and the Impermanence config sets up links in the root filesystem pointing to their persisted counterparts.
 

--- a/hosts/common/users/spencer.nix
+++ b/hosts/common/users/spencer.nix
@@ -1,10 +1,15 @@
 {
+  inputs,
   pkgs,
   config,
   ...
 }: let
   ifGroupExists = groups: builtins.filter (group: builtins.hasAttr group config.users.groups) groups;
 in {
+  imports = [
+    inputs.home-manager.nixosModules.home-manager
+  ];
+
   users.mutableUsers = false;
 
   users.users = {

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -60,7 +60,7 @@
     zfs = {
       enable = true;
       autoSnapshot = false; # TODO: configure and enable later
-      rollbackSnapshot = "rpool/local/root@blank";
+      impermanenceRollbackSnapshot = "rpool/crypt/local/root@blank";
       zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
       zedMailCommand = "${pkgs.notify}/bin/notify";
       zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -53,7 +53,7 @@
     };
   };
 
-  hyperparabolic.base.zfs = {
+  hyperparabolic.zfs = {
     enable = true;
     autoSnapshot = false; # TODO: configure and enable later
     rollbackSnapshot = "rpool/local/root@blank";

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -7,7 +7,6 @@
   ...
 }: {
   imports = [
-    inputs.home-manager.nixosModules.home-manager
     inputs.impermanence.nixosModules.impermanence
     # https://github.com/NixOS/nixos-hardware/tree/master/framework/13-inch/7040-amd
     inputs.nixos-hardware.nixosModules.framework-13-7040-amd

--- a/hosts/magnolia/configuration.nix
+++ b/hosts/magnolia/configuration.nix
@@ -52,13 +52,19 @@
     };
   };
 
-  hyperparabolic.zfs = {
-    enable = true;
-    autoSnapshot = false; # TODO: configure and enable later
-    rollbackSnapshot = "rpool/local/root@blank";
-    zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
-    zedMailCommand = "${pkgs.notify}/bin/notify";
-    zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+  hyperparabolic = {
+    impermanence = {
+      enable = true;
+      enableRollback = true;
+    };
+    zfs = {
+      enable = true;
+      autoSnapshot = false; # TODO: configure and enable later
+      rollbackSnapshot = "rpool/local/root@blank";
+      zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
+      zedMailCommand = "${pkgs.notify}/bin/notify";
+      zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+    };
   };
 
   hardware.graphics = {

--- a/hosts/oak/configuration.nix
+++ b/hosts/oak/configuration.nix
@@ -101,7 +101,7 @@
     };
   };
 
-  hyperparabolic.base.zfs = {
+  hyperparabolic.zfs = {
     enable = true;
     autoSnapshot = true;
     rollbackSnapshot = "rpool/crypt/local/root@blank";

--- a/hosts/oak/configuration.nix
+++ b/hosts/oak/configuration.nix
@@ -108,7 +108,7 @@
     zfs = {
       enable = true;
       autoSnapshot = true;
-      rollbackSnapshot = "rpool/crypt/local/root@blank";
+      impermanenceRollbackSnapshot = "rpool/crypt/local/root@blank";
       zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
       zedMailCommand = "${pkgs.notify}/bin/notify";
       zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";

--- a/hosts/oak/configuration.nix
+++ b/hosts/oak/configuration.nix
@@ -100,13 +100,19 @@
     };
   };
 
-  hyperparabolic.zfs = {
-    enable = true;
-    autoSnapshot = true;
-    rollbackSnapshot = "rpool/crypt/local/root@blank";
-    zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
-    zedMailCommand = "${pkgs.notify}/bin/notify";
-    zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+  hyperparabolic = {
+    impermanence = {
+      enable = true;
+      enableRollback = true;
+    };
+    zfs = {
+      enable = true;
+      autoSnapshot = true;
+      rollbackSnapshot = "rpool/crypt/local/root@blank";
+      zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
+      zedMailCommand = "${pkgs.notify}/bin/notify";
+      zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+    };
   };
 
   # there are some issues with non-legacymount datasets imported via boot.zfs.extraPools

--- a/hosts/oak/configuration.nix
+++ b/hosts/oak/configuration.nix
@@ -7,7 +7,6 @@
   ...
 }: {
   imports = [
-    inputs.home-manager.nixosModules.home-manager
     inputs.impermanence.nixosModules.impermanence
     inputs.nixos-hardware.nixosModules.common-gpu-intel
     inputs.nixos-hardware.nixosModules.common-hidpi

--- a/hosts/redbud/configuration.nix
+++ b/hosts/redbud/configuration.nix
@@ -50,13 +50,19 @@
     };
   };
 
-  hyperparabolic.zfs = {
-    enable = true;
-    autoSnapshot = false; # TODO: configure and enable later
-    rollbackSnapshot = "rpool/local/root@blank";
-    zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
-    zedMailCommand = "${pkgs.notify}/bin/notify";
-    zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+  hyperparabolic = {
+    impermanence = {
+      enable = true;
+      enableRollback = true;
+    };
+    zfs = {
+      enable = true;
+      autoSnapshot = false; # TODO: configure and enable later
+      rollbackSnapshot = "rpool/local/root@blank";
+      zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
+      zedMailCommand = "${pkgs.notify}/bin/notify";
+      zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+    };
   };
 
   # Remotely managed audio receiver, this is a bit hacky.

--- a/hosts/redbud/configuration.nix
+++ b/hosts/redbud/configuration.nix
@@ -58,7 +58,7 @@
     zfs = {
       enable = true;
       autoSnapshot = false; # TODO: configure and enable later
-      rollbackSnapshot = "rpool/local/root@blank";
+      impermanenceRollbackSnapshot = "rpool/local/root@blank";
       zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
       zedMailCommand = "${pkgs.notify}/bin/notify";
       zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";

--- a/hosts/redbud/configuration.nix
+++ b/hosts/redbud/configuration.nix
@@ -7,7 +7,6 @@
   ...
 }: {
   imports = [
-    inputs.home-manager.nixosModules.home-manager
     inputs.impermanence.nixosModules.impermanence
     inputs.nixos-hardware.nixosModules.common-cpu-intel
     inputs.nixos-hardware.nixosModules.common-pc-laptop

--- a/hosts/redbud/configuration.nix
+++ b/hosts/redbud/configuration.nix
@@ -51,7 +51,7 @@
     };
   };
 
-  hyperparabolic.base.zfs = {
+  hyperparabolic.zfs = {
     enable = true;
     autoSnapshot = false; # TODO: configure and enable later
     rollbackSnapshot = "rpool/local/root@blank";

--- a/hosts/warden/configuration.nix
+++ b/hosts/warden/configuration.nix
@@ -7,7 +7,6 @@
   ...
 }: {
   imports = [
-    inputs.home-manager.nixosModules.home-manager
     inputs.impermanence.nixosModules.impermanence
     inputs.nixos-hardware.nixosModules.common-cpu-intel
     inputs.nixos-hardware.nixosModules.common-pc

--- a/hosts/warden/configuration.nix
+++ b/hosts/warden/configuration.nix
@@ -94,7 +94,7 @@
     zfs = {
       enable = true;
       autoSnapshot = false; # TODO: configure and enable later
-      rollbackSnapshot = "rpool/crypt/local/root@blank";
+      impermanenceRollbackSnapshot = "rpool/crypt/local/root@blank";
       zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
       zedMailCommand = "${pkgs.notify}/bin/notify";
       zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";

--- a/hosts/warden/configuration.nix
+++ b/hosts/warden/configuration.nix
@@ -87,7 +87,7 @@
     };
   };
 
-  hyperparabolic.base.zfs = {
+  hyperparabolic.zfs = {
     enable = true;
     autoSnapshot = false; # TODO: configure and enable later
     rollbackSnapshot = "rpool/crypt/local/root@blank";

--- a/hosts/warden/configuration.nix
+++ b/hosts/warden/configuration.nix
@@ -86,13 +86,19 @@
     };
   };
 
-  hyperparabolic.zfs = {
-    enable = true;
-    autoSnapshot = false; # TODO: configure and enable later
-    rollbackSnapshot = "rpool/crypt/local/root@blank";
-    zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
-    zedMailCommand = "${pkgs.notify}/bin/notify";
-    zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+  hyperparabolic = {
+    impermanence = {
+      enable = true;
+      enableRollback = true;
+    };
+    zfs = {
+      enable = true;
+      autoSnapshot = false; # TODO: configure and enable later
+      rollbackSnapshot = "rpool/crypt/local/root@blank";
+      zedMailTo = "root"; # value doesn't matter, not using email, just needs to not be null;
+      zedMailCommand = "${pkgs.notify}/bin/notify";
+      zedMailCommandOptions = "-bulk -provider-config /run/secrets/notify-provider-config";
+    };
   };
 
   services.thermald.enable = true;

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,3 +1,4 @@
 {
+  impermanence = import ./impermanence.nix;
   zfs = import ./zfs.nix;
 }

--- a/modules/nixos/impermanence.nix
+++ b/modules/nixos/impermanence.nix
@@ -1,0 +1,64 @@
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
+  cfg = config.hyperparabolic.impermanence;
+in {
+  /*
+  Impermanence config. This is a little funky / exceptional.
+
+  This is extremely prescriptive about structure. All persist filesystems are expected
+  to be mounted at "/persist", and systems that use impermanence expect home-manager to
+  be included. All current usage in home-manager is also nested in the same directory
+  at "/perist/home/spencer" and relies on the nixos level for rollbacks and is specific
+  to the "spencer" user.
+
+  Nixos without home-manager would likely only be static deployments, and home-manager
+  without nixos would likely be darwin based work laptops. I don't think either of these
+  use cases would include impermanence.
+
+  Accepting all of this as givens for now, and co-mingling nixos and home-manager
+  here.
+  */
+
+  options.hyperparabolic.impermanence = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = mdDoc ''
+        Enables impermanence.
+
+        This enables impermanence for "/persist" in the nixos module, and
+        "/persist/home/spencer" in the home-manager module of impermanence.
+
+        Conditional imports aren't really possible unless the impermanence config
+        is completely isolated, and strongly prefer it to be co-mingled with the
+        relevant programs / services.
+
+        This mostly just exists to be more prescriptive about structure so that
+        the default can be made false, and this can be appled to both nixos and
+        home-manager.
+      '';
+    };
+    enableRollback = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = mdDoc ''
+        Perform impermance rollback on boot. Useful to disable for debugging.
+
+        Only intended to be consumed by a <fs>.nix module. A zfs or btrfs module
+        is expected to implement snapshot rollbacks based on this option. This
+        will do nothing if not using a local fs module that supports snapshots.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.persistence."/persist".enable = cfg.enable;
+    home-manager.users.spencer.home.persistence."/persist/home/spencer".enable = cfg.enable;
+  };
+}

--- a/modules/nixos/zfs.nix
+++ b/modules/nixos/zfs.nix
@@ -49,16 +49,15 @@ in {
       default = true;
       example = false;
     };
-    rollbackSnapshot = mkOption {
+    impermanenceRollbackSnapshot = mkOption {
       type = types.nullOr types.str;
       default = null;
       example = "rpool/local/root@empty";
       description = mdDoc ''
-        Empty zfs root filesystem dataset@snapshot. If provided, this will
-        rollback to that snapshot on boot.
-        See grahamc "Erase your darlings".
-        Leave this null if you aren't comfy with the idea of an ephemeral
-        filesystem from that.
+        Empty zfs root filesystem dataset@snapshot. If provided, and
+        hyperparabolic.impermanance.enableRoolback, then this will roll back
+        to the specified snapshot immediately after mounting the zfs pool
+        rpool.
       '';
     };
     zedMailTo = mkOption {
@@ -116,7 +115,7 @@ in {
       };
     }
 
-    (mkIf (enableImpermanenceRollback && cfg.rollbackSnapshot != null) {
+    (mkIf (enableImpermanenceRollback && cfg.impermanenceRollbackSnapshot != null) {
       # rollback root fs to blank snapshot
       boot.initrd.systemd.services.zfs-rollback = {
         description = "Rollback ZFS root dataset to blank snapshot";
@@ -135,7 +134,7 @@ in {
         unitConfig.DefaultDependencies = "no";
         serviceConfig.Type = "oneshot";
         script = ''
-          zfs rollback -r ${cfg.rollbackSnapshot} && echo "zfs rollback complete"
+          zfs rollback -r ${cfg.impermanenceRollbackSnapshot} && echo "zfs rollback complete"
         '';
       };
     })

--- a/modules/nixos/zfs.nix
+++ b/modules/nixos/zfs.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib; let
-  cfg = config.hyperparabolic.base.zfs;
+  cfg = config.hyperparabolic.zfs;
 
   # get latest zfs compatible kernel
   latestZfsCompatibleLinuxPackages = lib.pipe pkgs.linuxKernel.packages [
@@ -41,7 +41,7 @@ in {
   must be sufficient without that.
   */
 
-  options.hyperparabolic.base.zfs = {
+  options.hyperparabolic.zfs = {
     enable = mkEnableOption "Enable zfs";
     autoSnapshot = mkOption {
       type = types.bool;

--- a/modules/nixos/zfs.nix
+++ b/modules/nixos/zfs.nix
@@ -103,7 +103,7 @@ in {
       services.zfs = {
         autoScrub.enable = true;
         trim.enable = true;
-        autoSnapshot = mkIf (cfg.enable && cfg.autoSnapshot) {
+        autoSnapshot = mkIf (cfg.autoSnapshot) {
           enable = true;
           frequent = 12;
           hourly = 24;
@@ -139,7 +139,7 @@ in {
       };
     })
 
-    (mkIf (cfg.enable && cfg.zedMailTo != null) {
+    (mkIf (cfg.zedMailTo != null) {
       services.zfs = {
         zed = {
           # Bit of a misnomer I think? I believe this enables linux local mail


### PR DESCRIPTION
This is a big ol' no-op, but makes some future modules and hosts easier or possible to handle, and includes stylistic changes for modules that I intend to continue to exist long-term.

Impermanence is inherently very specific to fs state, and this change-set accepts this more explicitly. An impermanence module is added for managing "/persist" and "/persist/home/spencer", making the relationship to these specific directories more explicit, and separating zfs from impermanence rollbacks.