### PR TITLE
oak - expose hydra-notify and hydra-queue-runner prometheus metrics

### DIFF
--- a/hosts/oak/services/hydra.nix
+++ b/hosts/oak/services/hydra.nix
@@ -7,6 +7,15 @@
       listenHost = "localhost";
       useSubstitutes = true;
       buildMachinesFiles = ["/etc/nix/machines"];
+      extraConfig = ''
+        queue_runner_metrics_address = 0.0.0.0:9198
+        <hydra_notify>
+          <prometheus>
+            listen_address = 0.0.0.0
+            port = 9199
+          </prometheus>
+        </hydra_notify>
+      '';
     };
     nginx.virtualHosts."hydra.oak.decent.id" = {
       forceSSL = true;
@@ -27,6 +36,14 @@
       maxJobs = 8;
     }
   ];
+
+  # expose metrics to tailscale interface only
+  networking.firewall.interfaces."tailscale0" = {
+    allowedTCPPorts = [
+      9198 # hydra-queue-runner
+      9199 # hydra-notify
+    ];
+  };
 
   environment.persistence = {
     "/persist".directories = [

--- a/hosts/redbud/services/prometheus.nix
+++ b/hosts/redbud/services/prometheus.nix
@@ -14,6 +14,26 @@ in {
       ];
       scrapeConfigs = [
         {
+          job_name = "hosts";
+          scheme = "http";
+          static_configs =
+            map (hostname: {
+              labels.instance = hostname;
+              targets = ["${hostname}:${toString config.services.prometheus.exporters.node.port}"];
+            })
+            hosts;
+        }
+        {
+          job_name = "hydra-notify";
+          scheme = "http";
+          static_configs = [{targets = ["oak:9199"];}];
+        }
+        {
+          job_name = "hydra-queue-runner";
+          scheme = "http";
+          static_configs = [{targets = ["oak:9198"];}];
+        }
+        {
           job_name = "grafana";
           scheme = "https";
           static_configs = [{targets = ["dash.redbud.decent.id"];}];
@@ -27,16 +47,6 @@ in {
           job_name = "smokeping";
           scheme = "http";
           static_configs = [{targets = ["warden:${toString config.services.prometheus.exporters.smokeping.port}"];}];
-        }
-        {
-          job_name = "hosts";
-          scheme = "http";
-          static_configs =
-            map (hostname: {
-              labels.instance = hostname;
-              targets = ["${hostname}:${toString config.services.prometheus.exporters.node.port}"];
-            })
-            hosts;
         }
       ];
     };


### PR DESCRIPTION
redbud - consume these prometheus metrics