### PR TITLE
remove all full packages overlays

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,23 +513,6 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs-gcc14": {
-      "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
-        "type": "github"
-      },
-      "original": {
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1777168982,
@@ -680,7 +663,6 @@
         "nixos-hardware": "nixos-hardware",
         "nixos-hydra-upgrade": "nixos-hydra-upgrade",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-gcc14": "nixpkgs-gcc14",
         "sops-nix": "sops-nix",
         "stylix": "stylix",
         "systems": "systems_4",

--- a/flake.lock
+++ b/flake.lock
@@ -561,22 +561,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1780453794,
-        "narHash": "sha256-bXMRa9VTsHSPXL4Cw8R6JJLQeY3Y/IP4+YJCYVmQ7FY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "6b316287bae2ee04c9b93c8c858d930fd07d7338",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-26.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1780243769,
@@ -697,7 +681,6 @@
         "nixos-hydra-upgrade": "nixos-hydra-upgrade",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-gcc14": "nixpkgs-gcc14",
-        "nixpkgs-stable": "nixpkgs-stable_2",
         "sops-nix": "sops-nix",
         "stylix": "stylix",
         "systems": "systems_4",

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-gcc14.url = "github:nixos/nixpkgs/3e2499d5539c16d0d173ba53552a4ff8547f4539?narHash=sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU%3D";
 
     systems.url = "github:nix-systems/default-linux";
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
   inputs = {
     # Nixpkgs
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-26.05";
     nixpkgs-gcc14.url = "github:nixos/nixpkgs/3e2499d5539c16d0d173ba53552a4ff8547f4539?narHash=sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU%3D";
 
     systems.url = "github:nix-systems/default-linux";

--- a/modules/core/cli/starship.nix
+++ b/modules/core/cli/starship.nix
@@ -2,7 +2,7 @@
   flake.modules.homeManager.core = {pkgs, ...}: {
     programs.starship = {
       enable = true;
-      package = pkgs.stable.starship;
+      package = pkgs.starship;
       enableFishIntegration = true;
       settings = {
       };

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -16,7 +16,7 @@
       grimblast
       slurp
       hyprpicker
-      stable.wl-screenrec
+      wl-screenrec
 
       # clipboard and utils
       cliphist

--- a/modules/flake-parts/overlays.nix
+++ b/modules/flake-parts/overlays.nix
@@ -4,10 +4,5 @@
     lazy-app = final: _: {
       lazy-app = inputs.lazy-apps.packages.${final.stdenv.hostPlatform.system}.lazy-app;
     };
-
-    # TODO: remove after gcc15 breakages are ironed out
-    packages-gcc14 = final: _: {
-      gcc14 = inputs.nixpkgs-gcc14.legacyPackages.${final.stdenv.hostPlatform.system};
-    };
   };
 }

--- a/modules/flake-parts/overlays.nix
+++ b/modules/flake-parts/overlays.nix
@@ -4,10 +4,6 @@
     lazy-app = final: _: {
       lazy-app = inputs.lazy-apps.packages.${final.stdenv.hostPlatform.system}.lazy-app;
     };
-    # adds pkgs.stable for package versions from stable release`
-    packages-stable = final: _: {
-      stable = inputs.nixpkgs-stable.legacyPackages.${final.stdenv.hostPlatform.system};
-    };
 
     # TODO: remove after gcc15 breakages are ironed out
     packages-gcc14 = final: _: {

--- a/modules/hosts/oak/services/hydra.nix
+++ b/modules/hosts/oak/services/hydra.nix
@@ -6,8 +6,7 @@
   }: {
     services = {
       hydra = {
-        # TODO: revert to unstable once gcc15 migrations complete, currently borked
-        package = pkgs.gcc14.hydra;
+        package = pkgs.hydra;
         enable = true;
         hydraURL = "https://hydra.oak.decent.id";
         notificationSender = "hydra@localhost";

--- a/modules/hosts/oak/services/jellyfin.nix
+++ b/modules/hosts/oak/services/jellyfin.nix
@@ -4,7 +4,7 @@
       jellyfin = {
         enable = true;
         openFirewall = true;
-        package = pkgs.stable.jellyfin;
+        package = pkgs.jellyfin;
       };
       nginx.virtualHosts."jellyfin.oak.decent.id" = {
         forceSSL = true;


### PR DESCRIPTION
I don't currently rely on any stable packages, so it's a good time to do this.

New systemd service validations introduced as a part of making stage1 systemd default fail on services that are generated as a part of the hydra service fail if you have a full packages overlay like these.

If I need stable packages again in the future, I'll need to find some other way to include them.